### PR TITLE
Support exiting with an errorcode

### DIFF
--- a/bin/nvr
+++ b/bin/nvr
@@ -81,21 +81,29 @@ class Neovim():
                 self.server.command('augroup nvr')
                 self.server.command('autocmd BufDelete <buffer> silent! call rpcnotify({}, "BufDelete")'.format(self.server.channel_id))
                 self.server.command('augroup END')
+                self.server.command('command -buffer Cq silent! call rpcnotify({}, "ErrorQuit")'.format(self.server.channel_id))
         if c:
             self.server.command(c)
         if wait:
             bufcount = len(arguments) - (1 if c else 0)
+            exitfail = False
             def notification_cb(msg, _args):
                 nonlocal bufcount
+                nonlocal exitfail
                 if msg == 'BufDelete':
                     bufcount -= 1
                     if bufcount == 0:
                         self.server.stop_loop()
+                elif msg == 'ErrorQuit':
+                    self.server.stop_loop()
+                    exitfail = True
             def err_cb(error):
                 print(error, file=sys.stderr)
                 self.server.stop_loop()
-                sys.exit(1)
+                exitfail = True
             self.server.run_loop(None, notification_cb, None, err_cb)
+            if exitfail:
+                sys.exit(1)
 
     def _show_msg(self):
         a = self.address


### PR DESCRIPTION
Support exiting ```nvr``` with an errorcode when started waiting. It also turned out ```sys.exit(1)``` with ```run_loop()``` running throws an exception, so exit when the loop is finished.