### PR TITLE
Windows workaround for lack of os.fork capability.

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -310,7 +310,7 @@ def prepare_filename(fname):
 
 
 def get_pipenames_for_printing():
-    return ["win32 pipe: {}".format(pipename) for pipename in os.listdir('\\\\.\\pipe')]
+    return ["win32 pipe: {}".format(pipename) for pipename in os.listdir('\\\\.\\pipe') if 'nvim' in pipename]
 
 def get_sockaddrs_for_printing(proc):
     sockaddrs = []

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -113,7 +113,7 @@ def start_nvim_with_specified_server_address(address):
     os.environ['NVIM_LISTEN_ADDRESS'] = address
     try:
         args = os.environ.get('NVR_CMD')
-        args = args.split(' ') if args else ['nvim-qt']
+        args = args.split(' ') if args else ['nvim']
         
         if sys.platform == 'win32':
             proc = subprocess.Popen([args[0], args, os.environ])

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -344,7 +344,7 @@ def get_address_type(address):
     except ValueError:
         return 'socket'
     
-def create_pipe_name():
+def create_new_pipe_name():
     existing_pipenames = [pipename for pipename in os.listdir('\\\\.\\pipe') ]
     pipename = "\\\\.\\pipe\\nvr-{}".format(random.randint(0, 10000))
     
@@ -364,7 +364,7 @@ def main(argv=sys.argv, env=os.environ):
         return
 
     if sys.platform == 'win32':
-        address = options.servername or env.get('NVIM_LISTEN_ADDRESS') or create_pipe_name()
+        address = options.servername or env.get('NVIM_LISTEN_ADDRESS') or create_new_pipe_name()
     else:
         address = options.servername or env.get('NVIM_LISTEN_ADDRESS') or os.path.join(tempfile.gettempdir(), 'nvimsocket')
 

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -315,7 +315,7 @@ def get_sockaddrs_for_printing(proc):
     for conn in proc.connections('inet4'):
             sockaddrs.insert(0, ':'.join(map(str, conn.laddr)))
             
-    if sys.platform != "win32":
+    if sys.platform == "win32":
         sockaddrs += ["win32 pipe: {}".format(pipename) for pipename in os.listdir('\\\\.\\pipe')]
     else:
         for conn in proc.connections('unix'):

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -123,7 +123,7 @@ def start_nvim_with_specified_server_address(address):
             os.execvpe(args[0], args, os.environ)
     except FileNotFoundError:
         if sys.platform == 'win32':
-            print("[!] Can't start new nvim process: '{}' is not in $PATH.".format(args[0]))
+            print("[!] Can't start new nvim process: '{}' is not in %PATH%.".format(args[0]))
         else:
             print("[!] Can't start new nvim process: '{}' is not in $PATH.".format(args[0]))
         sys.exit(1)
@@ -316,12 +316,12 @@ def get_sockaddrs_for_printing(proc):
             sockaddrs.insert(0, ':'.join(map(str, conn.laddr)))
             
     if sys.platform != "win32":
+        sockaddrs += ["win32 pipe: {}".format(pipename) for pipename in os.listdir('\\\\.\\pipe')]
+    else:
         for conn in proc.connections('unix'):
             if conn.laddr:
                 sockaddrs.insert(0, conn.laddr)
-        sockaddrs += ["win32 pipe: {}".format(pipename) for pipename in os.listdir('\\\\.\\pipe')]
             
-                
     return sockaddrs
 
 
@@ -375,8 +375,6 @@ def main(argv=sys.argv, env=os.environ):
         if sys.platform == 'win32':
             start_nvim_with_specified_server_address(address)
             nvr.attach()
-            print(address)
-            print(nvr.server)
             
             if not nvr.server:
                 print("Could not attach to server at address: {}".format(address))

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -332,9 +332,11 @@ def main(argv=sys.argv, env=os.environ):
 
     if sys.platform == 'win32':
         address = options.servername or env.get('NVIM_LISTEN_ADDRESS') or None
-        if address == None:
-            print("Windows workaround: could not find an address! Set environment variable 'NVIM_LISTEN_ADDRESS', or pass a server address when calling nvr: `nvr --servername \\some\\server\\address`.")
-            # possibility: what could be a good temp file location on windows? Once we decide on this, we could use the subprocess possibility described below to start an nvim process on windows using this temp server. 
+        if not address:
+            print("Windows workaround: could not find an address! Set "
+      "environment variable 'NVIM_LISTEN_ADDRESS', or pass "
+      "a server address when calling nvr: "
+      "`nvr --servername \\some\\server\\address`.")
             sys.exit(1)
     else:
         address = options.servername or env.get('NVIM_LISTEN_ADDRESS') or '/tmp/nvimsocket'
@@ -344,10 +346,9 @@ def main(argv=sys.argv, env=os.environ):
 
     if not nvr.server:
         if sys.platform == 'win32':
-            print("Windows workaround: nvr on Windows can only attach to existing neovim processes! Could not attach to supplied server address: {}.".format(address))
+            print("nvr on Windows can only attach to existing neovim processes. "
+            "Could not attach to supplied server address: {}.".format(address))
             sys.exit(1)
-            # possibility: use user supplied address to start an nvim process as subprocess (see https://docs.python.org/3.6/library/subprocess.html)
-            # but I don't know how to start nvim on windows with such an address: https://vi.stackexchange.com/questions/14883/how-do-i-set-nvim-listen-address-on-startup-using-windows
         else:
             nvr.address = sanitize_address(address)
             silent = options.remote_silent or options.remote_wait_silent or options.remote_tab_silent or options.remote_tab_wait_silent or options.s

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -334,6 +334,7 @@ def main(argv=sys.argv, env=os.environ):
         address = options.servername or env.get('NVIM_LISTEN_ADDRESS') or None
         if address == None:
             print("Windows workaround: could not find an address! Set environment variable 'NVIM_LISTEN_ADDRESS', or pass a server address when calling nvr: `nvr --servername \\some\\server\\address`.")
+            # possibility: what could be a good temp file location on windows? Once we decide on this, we could use the subprocess possibility described below to start an nvim process on windows using this temp server. 
             sys.exit(1)
     else:
         address = options.servername or env.get('NVIM_LISTEN_ADDRESS') or '/tmp/nvimsocket'

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -352,14 +352,13 @@ def create_pipe_name():
         if pipename not in existing_pipenames:
             return pipename
     
-    print("Could not figure out name for new neovim pipe. Too many existing pipes? Run `nvr --serverlist` to get a list of existing pipes.")
+    print("Could not get name for new neovim pipe." "Too many existing pipes?" "Run `nvr --serverlist` to get a list of existing pipes.")
     sys.exit(1)
     
 
 def main(argv=sys.argv, env=os.environ):
     options, arguments = parse_args(argv)
-    print(options)
-    print(arguments)
+    
     if options.serverlist:
         print_sockaddrs()
         return

--- a/tests/test_nvr.py
+++ b/tests/test_nvr.py
@@ -5,17 +5,25 @@ import time
 import signal
 import subprocess
 import nvr
+import sys
+import tempfile
 
 def test_open_and_write_file():
+    if sys.platform == 'win32':
+        env = {'NVIM_LISTEN_ADDRESS': nvr.create_new_pipe_name()}
+        
     env = {'NVIM_LISTEN_ADDRESS': '/tmp/pytest_nvimsock'}
     env.update(os.environ)
 
+    test_file_path = os.path.join(tempfile.gettempdir(), "pytest_file")
+    
     with subprocess.Popen(['nvim', '-nu', 'NORC', '--headless'], close_fds=True,
                           env=env) as proc:
         time.sleep(1)
-        argv = ['nvr', '-c', 'e /tmp/pytest_file | %d | exe "norm! iabc" | w']
+        
+        argv = ['nvr', '-c', 'e {} | %d | exe "norm! iabc" | w'.format(test_file_path)]
         nvr.main(argv=argv, env=env)
         proc.send_signal(signal.SIGTERM)
 
-    with open('/tmp/pytest_file') as f:
+    with open(test_file_path) as f:
         assert 'abc\n' == f.read()

--- a/tests/test_nvr.py
+++ b/tests/test_nvr.py
@@ -12,7 +12,7 @@ def test_open_and_write_file():
     if sys.platform == 'win32':
         env = {'NVIM_LISTEN_ADDRESS': nvr.create_new_pipe_name()}
     else:
-        env = {'NVIM_LISTEN_ADDRESS': '/tmp/pytest_nvimsock'}
+        env = {'NVIM_LISTEN_ADDRESS': os.path.join(tempfile.gettempdir(), "pytest_nvimsock")}
         
     env.update(os.environ)
 

--- a/tests/test_nvr.py
+++ b/tests/test_nvr.py
@@ -11,8 +11,9 @@ import tempfile
 def test_open_and_write_file():
     if sys.platform == 'win32':
         env = {'NVIM_LISTEN_ADDRESS': nvr.create_new_pipe_name()}
+    else:
+        env = {'NVIM_LISTEN_ADDRESS': '/tmp/pytest_nvimsock'}
         
-    env = {'NVIM_LISTEN_ADDRESS': '/tmp/pytest_nvimsock'}
     env.update(os.environ)
 
     test_file_path = os.path.join(tempfile.gettempdir(), "pytest_file")


### PR DESCRIPTION
`neovim-remote` (`nvr`) is a crucial for dealing with a neovim regression: lack of native --remote support (see issue: https://github.com/neovim/neovim/issues/1750).  For example, vimtex relies on `nvr`: https://github.com/lervag/vimtex/issues/262

However, `nvr` has been Unix only so far, because Windows does not have the capacity to create forked processes, and it is in fact very difficult to emulate this. See: https://www.cygwin.com/faq.html#faq.api.fork

`nvr` forks in order to create new `nvim` processes if no existing ones are found.

So a temporary fix (as in this pull request), is to simply remove `nvr`'s capability to start its own `nvim` processes on Windows, and only let it attach to existing processes. There are still a couple of things that could be done to deal with this issue more gracefully, but I am not sure how to exactly implement them: 

* What could be a good temp file location on Windows comparable to `/tmp/nvimsocket`? Instead of relying on the user to supply a `--servername` or set a `NVIM_LISTEN_ADDRESS` environment variable, we can fall back to this.

**UPDATE:** we can use [`tempfile`](https://docs.python.org/3.6/library/tempfile.html) as an OS independent solution!

* If an `nvim` process with the user specified server address (or, the temp address, if the first point is implemented) is not available, `nvr` could start an nvim process as `subprocess` (see https://docs.python.org/3.6/library/subprocess.html) using this specified address, but I don't know how to start `nvim` on windows with such an address: https://vi.stackexchange.com/questions/14883/how-do-i-set-nvim-listen-address-on-startup-using-windows 

**UPDATE:** @jamessan had some ideas on this. We could just set the environment variable `NVIM_LISTEN_ADDRESS`, and then call a `subprocess` (e.g. like what `start_process` does in current `nvr`), this seems to work on windows!