### PR TITLE
Add functionality to set global variables from the command line

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -247,6 +247,11 @@ def parse_args(argv):
     parser.add_argument('-t',
             metavar = '<tag>',
             help    = 'Jump to file and position of given tag.')
+    parser.add_argument('--set-var', '-V',
+            metavar = ('<name>', '<value>'),
+            help    = 'Set neovim global variable <name> to <value> before proceeding',
+            nargs   = 2,
+            action  = 'append')
     parser.add_argument('--nostart',
             action  = 'store_true',
             help    = 'If no process is found, do not start a new one.')
@@ -353,6 +358,10 @@ def main(argv=sys.argv, env=os.environ):
             sys.exit(1)
         else:
             nvr.start_new_process()
+
+    if options.set_var:
+        for k, v in options.set_var:
+            nvr.server.vars[k] = v
 
     if options.cc:
         for cmd in options.cc:


### PR DESCRIPTION
This makes it much easier to safely pass strings into neovim.

I have attempted to write a test for this feature but couldn't get it to work. That attempt is on lf-/neovim-remote, branch tests.