### PR TITLE
Added option to read from stdin into a neovim register.

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -288,6 +288,11 @@ def parse_args(argv):
     parser.add_argument('-q',
             metavar = '<errorfile>',
             help    = 'Read errorfile into quickfix list and display first error.')
+    parser.add_argument('-r',
+            metavar = '[a-z0-9]',
+            nargs   = '?',
+            const   = ' ',  # empty strings are not allowed, fix this manually in main
+            help    = 'Read stdin into a named register, or into the unnamed register when no argument is supplied.')
     parser.add_argument('-s',
             action  = 'store_true',
             help    = 'Silence "no server found" message.')
@@ -539,6 +544,15 @@ def main(argv=sys.argv, env=os.environ):
             if cmd == '-':
                 cmd = sys.stdin.read()
             nvr.server.command(cmd)
+
+    if options.r:
+        try:
+            if options.r == ' ':
+                options.r = ''
+            contents = sys.stdin.read()
+            nvr.server.funcs.setreg(options.r, contents, 'l')
+        except UnicodeDecodeError:
+            raise RuntimeError("Cannot parse stdin into a register, make sure it contains valid UTF-8 encoded input.")
 
     wait_for_n_buffers = nvr.wait
     if wait_for_n_buffers > 0:

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -259,6 +259,17 @@ def parse_args(argv):
             action  = 'store_true',
             help    = 'Print the TCPv4 and Unix domain socket addresses of all nvim processes.')
 
+    parser.add_argument('--getreg',
+            metavar = '[a-z0-9]',
+            nargs   = '?',
+            const   = ' ',  # empty strings are not allowed, fix this manually in main
+            help    = 'Write named register to stdout, will default to the unnamed register when no argument is supplied.')
+    parser.add_argument('--setreg',
+            metavar = '[a-z0-9]',
+            nargs   = '?',
+            const   = ' ',  # empty strings are not allowed, fix this manually in main
+            help    = 'Read stdin into a named register, or into the unnamed register when no argument is supplied.')
+
     parser.add_argument('-cc',
             action  = 'append',
             metavar = '<cmd>',
@@ -288,11 +299,6 @@ def parse_args(argv):
     parser.add_argument('-q',
             metavar = '<errorfile>',
             help    = 'Read errorfile into quickfix list and display first error.')
-    parser.add_argument('-r',
-            metavar = '[a-z0-9]',
-            nargs   = '?',
-            const   = ' ',  # empty strings are not allowed, fix this manually in main
-            help    = 'Read stdin into a named register, or into the unnamed register when no argument is supplied.')
     parser.add_argument('-s',
             action  = 'store_true',
             help    = 'Silence "no server found" message.')
@@ -545,12 +551,18 @@ def main(argv=sys.argv, env=os.environ):
                 cmd = sys.stdin.read()
             nvr.server.command(cmd)
 
-    if options.r:
+    if options.getreg:
+        if options.getreg == ' ':
+            options.getreg = ''
+        content = nvr.server.funcs.getreg(options.getreg)
+        print(content, end='')
+
+    if options.setreg:
         try:
-            if options.r == ' ':
-                options.r = ''
+            if options.setreg == ' ':
+                options.setreg = ''
             contents = sys.stdin.read()
-            nvr.server.funcs.setreg(options.r, contents, 'l')
+            nvr.server.funcs.setreg(options.setreg, contents, 'l')
         except UnicodeDecodeError:
             raise RuntimeError("Cannot parse stdin into a register, make sure it contains valid UTF-8 encoded input.")
 


### PR DESCRIPTION
I've added an option `-r` which will read from stdin into a neovim register, similarly to xclip. The benefit here is that it is added directly into a (un)named register.

Examples
```bash
echo 41 | nvr -r a
echo 42 | nvr -r
echo 43 | nvr -r '*'
echo 44 | nvr -r '+'
```
The first line puts "41\n" into the named register a, the second line puts "42\n" into the unnamed register. Access to the x11 clipboard is a bonus.

It is possible to extend this functionality and provide a read-register option. That way one would have access to the dozens of registers outside the terminal environment instead of 1 or 2 system clipboards.