### PR TITLE
setqflist requires a List

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -508,7 +508,7 @@ def main(argv=sys.argv, env=os.environ):
     if options.q:
         path = nvr.server.funcs.fnameescape(os.environ['PWD'])
         nvr.server.command('lcd {}'.format(path))
-        nvr.server.funcs.setqflist('[]')
+        nvr.server.funcs.setqflist([])
         if options.q == '-':
             for line in sys.stdin:
                 nvr.server.command("caddexpr '{}'".


### PR DESCRIPTION
If I do `nvr -q ~/myfile` I will get:

```
Traceback (most recent call last):
  File "/home/linuxbrew/.linuxbrew/bin/nvr", line 10, in <module>
    sys.exit(main())
  File "/home/linuxbrew/.linuxbrew/opt/python/lib/python3.7/site-packages/nvr/nvr.py", line 511, in main
    nvr.server.funcs.setqflist('[]')
  File "/home/linuxbrew/.linuxbrew/opt/python/lib/python3.7/site-packages/pynvim/api/nvim.py", line 299, in call
    return self.request('nvim_call_function', name, args, **kwargs)
  File "/home/linuxbrew/.linuxbrew/opt/python/lib/python3.7/site-packages/pynvim/api/nvim.py", line 182, in request
    res = self._session.request(name, *args, **kwargs)
  File "/home/linuxbrew/.linuxbrew/opt/python/lib/python3.7/site-packages/pynvim/msgpack_rpc/session.py", line 102, in request
    raise self.error_wrapper(err)
pynvim.api.nvim.NvimError: b'Vim:E714: List required'
```

I guess it was ok before and then https://github.com/mhinz/neovim-remote/commit/f104f234d9f44349d81fcb16c024c7b85831612c broke it. There are not tests for the `-q` parameter, if you want I can make a more "formal" PR adding it (right now I just edited the file from Github).