### PR TITLE
Shell: add bash autocompletion file

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,3 +290,9 @@ Using nvr from within `:terminal`: ![Demo 2](https://github.com/mhinz/neovim-rem
         \| endif
     ```
 
+- **Can I have auto-completion for bash?**
+
+    If you want basic auto-completion for bash, you can source [this
+    script](contrib/completion.bash) in your .bashrc.
+
+    This also completes server names with the `--servername` option.

--- a/contrib/completion.bash
+++ b/contrib/completion.bash
@@ -1,0 +1,53 @@
+#/usr/bin/env bash
+# bash command completion for neovim remote.
+# Source that file in your bashrc to use it.
+
+_nvr_opts_completions()
+{
+    local cur prev opts
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+    opts=(
+        -h
+        -cc
+        -c
+        -d
+        -l
+        -o
+        -O
+        -p
+        -q
+        -s
+        -t
+        --nostart
+        --version
+        --serverlist
+        --servername
+        --remote
+        --remote-wait
+        --remote-silent
+        --remote-wait-silent
+        --remote-tab
+        --remote-tab-wait
+        --remote-tab-silent
+        --remote-tab-wait-silent
+        --remote-send
+        --remote-expr
+    )
+    case "${prev}" in
+        --servername)
+            srvlist=$(nvr --serverlist)
+            COMPREPLY=( $(compgen -W "${srvlist}" -- "$cur") )
+            return 0
+            ;;
+    esac
+    if [[ "$cur" =~ ^- ]]; then
+        COMPREPLY=( $(compgen -W "${opts[*]}" -- "$cur") )
+        return 0
+    fi
+
+    COMPREPLY=()
+    return 0
+}
+
+complete -o default -F _nvr_opts_completions nvr


### PR DESCRIPTION
So, I've been using nvr quite a lot lately, and one thing that my lazy fingers really missed is the autocompletion feature.

Well, here it is !

It is for bash only though, I'm not used to zsh or other shell so I won't risk implementing it...