### PR TITLE
Dealing with AccessDenied exception on process connections

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -360,11 +360,14 @@ def print_sockaddrs():
 
     for proc in psutil.process_iter():
         if proc.name() == 'nvim':
-            for conn in proc.connections('inet4'):
-                sockaddrs.insert(0, ':'.join(map(str, conn.laddr)))
-            for conn in proc.connections('unix'):
-                if conn.laddr:
-                    sockaddrs.insert(0, conn.laddr)
+            try:
+                for conn in proc.connections('inet4'):
+                    sockaddrs.insert(0, ':'.join(map(str, conn.laddr)))
+                for conn in proc.connections('unix'):
+                    if conn.laddr:
+                        sockaddrs.insert(0, conn.laddr)
+            except psutil.AccessDenied:
+                sockaddrs.insert(0, 'Access denied for nvim ({})'.format(proc.pid))
 
     for addr in sorted(sockaddrs):
         print(addr)


### PR DESCRIPTION
In a multi-user context, there might be an exception occuring when calling `--servername` option.

#### Step to reproduce:
Try starting a nvim session with root (for example) and with the current user.

An exception will then occurs when using `--servername` option.

This PR catches the raised exception and let the user know that the connections was denied.