### PR TITLE
Add -n option to prevent the output of a newline

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -276,6 +276,9 @@ def parse_args(argv):
     parser.add_argument('-l',
             action  = 'store_true',
             help    = 'Change to previous window via ":wincmd p".')
+    parser.add_argument('-n',
+            action  = 'store_true',
+            help    = 'Do not include a trailing newline when printing the output from --remote-expr')
     parser.add_argument('-o',
             nargs   = '+',
             metavar = '<file>',
@@ -465,7 +468,10 @@ def main(argv=sys.argv, env=os.environ):
         elif type(result) is dict:
             print({ (k.decode() if type(k) is bytes else k): v for (k,v) in result.items() })
         else:
-            print(result)
+            end = '\n'
+            if options.n:
+                end = ''
+            print(result, end=end)
 
     if options.o:
         if options.d and not nvr.started_new_process:

--- a/tests/test_nvr.py
+++ b/tests/test_nvr.py
@@ -67,3 +67,21 @@ def test_escape_double_quotes_in_filenames(capsys):
     nvim.terminate()
     out, err = capsys.readouterr()
     assert filename == out.rstrip()
+
+def test_newline_printed_by_default(capsys):
+    env = setup_env()
+    nvim = run_nvim(env)
+    cmd = ['nvr', '--nostart', '--remote-expr', '"hello"']
+    run_nvr([cmd], env)
+    nvim.terminate()
+    out, err = capsys.readouterr()
+    assert out == 'hello\n'
+
+def test_newline_not_printed_when_disabled(capsys):
+    env = setup_env()
+    nvim = run_nvim(env)
+    cmd = ['nvr', '--nostart', '-n', '--remote-expr', '"hello"']
+    run_nvr([cmd], env)
+    nvim.terminate()
+    out, err = capsys.readouterr()
+    assert out == 'hello'


### PR DESCRIPTION
`nvr --remote-expr "$expr"` will always add a trailing newline character when printing the output it got from the `nvim` server. This is usually fine, but there are use cases where this behavior is really inconvenient.

For example, if I wanted a program that read the contents of my `"` register and print it out to `stdout`, it's tempting to write

```bash
#!/bin/bash
nvr --remote-expr 'getreg()'
```

but this doesn't quite work since if I yank a single word (`yw`), and try to print it with this program, the program writes to stdout a newline character at the end. If you're using `bash` or a another POSIX-compatible shell, you might try to work around this problem using command substitution like so:

```bash
#!/bin/bash
content=$(nvr --remote-expr 'getreg()')
echo -n "$content"
```

This program solves the single-word yank case, but fails in a different case. The problem here is that command substitution will always remove _all_ trailing newline characters produced by the command. So, if I yank a whole line (`yy`), this new program actually removes newline characters that are significant.

It's possible to write a program that correctly gets the entire output from `nvr`, then removes the final (and only the final) newline character, but it is cumbersome:

```bash
#!/bin/bash
IFS= read -r -d '' content < <(nvr --remote-expr 'getreg()')
echo -n "${content%?}"
```

What I think would be convenient is the ability to get the unmodified output from the call to `eval`, without anything added. This PR adds the `-n` option, which tries to accomplish this. `-n` here mirrors the behavior of the builtin `echo`, since `echo -n` will not print a trailing newline.

With this change,

```bash
#!/bin/bash
nvr --remote-expr 'getreg()'
```

does exactly what it did before (print a newline at the end), but

```bash
#!/bin/bash
nvr -n --remote-expr 'getreg()'
```

instead reproduces the output verbatim from the call to `eval`.