### PR TITLE
Add other filetypes to `set bufhidden=delete` autocmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Happy hacking!
     put the following in your vimrc:
 
     ```vim
-    autocmd FileType gitcommit set bufhidden=delete
+    autocmd FileType gitcommit,gitrebase,gitconfig set bufhidden=delete
     ```
 
     To use nvr from a regular shell as well:


### PR DESCRIPTION
Running `git config --edit` or `git rebase --interactive` will open a
buffer in neovim with a filetype of `gitconfig` or `gitrebase`
respectively. We want these buffers to be deleted automatically when
they're hidden just like buffers with filetype `gitcommit` so let's add
them to the relevant note in the README.