### PR TITLE
Add comment about reshimming Python with asdf

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -21,6 +21,12 @@ This will give you the correct location:
 
     $ python3 -c 'import site; print(site.USER_BASE)'
 
+If `nvr` is not in your path and you installed Python with `asdf`, you might need
+to reshim:
+
+    $ pip3 install neovim-remote
+    $ asdf reshim python
+
 ## From repo
 
 If you want to test your own changes, it makes sense to put your local repo into


### PR DESCRIPTION
After installing this package with `pip3 install neovim-remote`, the executable `nvr` was not available in my path. I use [`asdf`](https://github.com/asdf-vm/asdf) to manage installation of most languages, but I never use Python for development personally (I only have it installed for cases like this, where I need to install a tool written in Python directly from `pip`). `INSTALLATION.md` didn't help me, so I thought it might be worth adding some instructions here for others who might be in a similar position as me.

Thank you very much for this tool!