### PR TITLE
Windows specific patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ And do this in another shell:
 nvr --remote file1 file2
 
 # Send keys to the current buffer:
-nvr --remote-send 'iabc<esc>'
-# Enter insert mode, insert 'abc', and go back to normal mode again.
+nvr --remote-send "iabc<esc>"
+# Enter insert mode, insert "abc", and go back to normal mode again.
 
 # Evaluate any VimL expression, e.g. get the current buffer:
-nvr --remote-expr 'bufname("")'
+nvr --remote-expr "bufname("")"
 README.md
 ```
 
@@ -76,8 +76,8 @@ Remote control Neovim processes.
 
 If no process is found, a new one will be started.
 
-    $ nvr --remote-send 'iabc<cr><esc>'
-    $ nvr --remote-expr 'map([1,2,3], "v:val + 1")'
+    $ nvr --remote-send "iabc<cr><esc>"
+    $ nvr --remote-expr "map([1,2,3], 'v:val + 1')"
 
 Any arguments not consumed by options will be fed to --remote-silent:
 
@@ -88,8 +88,8 @@ All --remote options take optional commands.
 Exception: --remote-expr, --remote-send.
 
     $ nvr +10 file
-    $ nvr +'echomsg "foo" | echomsg "bar"' file
-    $ nvr --remote-tab-wait +'set bufhidden=delete' file
+    $ nvr +"echomsg 'foo' | echomsg 'bar'" file
+    $ nvr --remote-tab-wait +"set bufhidden=delete" file
 
 Open files in a new window from a terminal buffer:
 
@@ -97,7 +97,7 @@ Open files in a new window from a terminal buffer:
 
 Use nvr from git to edit commit messages:
 
-    $ git config --global core.editor 'nvr --remote-wait-silent'
+    $ git config --global core.editor "nvr --remote-wait-silent"
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -186,12 +186,12 @@ Happy hacking!
     Running `git commit` in a regular shell starts a nvim process. But in a
     terminal buffer (`:terminal`), a new nvim process starts as well. Now you
     have one nvim nested within another.
-    
+
     If you do not want this, put this in your vimrc:
 
     ```vim
-    if has('nvim')
-      let $GIT_EDITOR = 'nvr -cc split --remote-wait'
+    if has("nvim")
+      let $GIT_EDITOR = "nvr -cc split --remote-wait"
     endif
     ```
 
@@ -208,7 +208,7 @@ Happy hacking!
 
     To use nvr from a regular shell as well:
 
-        $ git config --global core.editor 'nvr --remote-wait-silent'
+        $ git config --global core.editor "nvr --remote-wait-silent"
 
 - **Use nvr as git mergetool.**
 
@@ -223,7 +223,7 @@ Happy hacking!
     [merge]
         tool = nvr
     [mergetool "nvr"]
-        cmd = nvr -s -d $LOCAL $BASE $REMOTE $MERGED -c 'wincmd J | wincmd ='
+        cmd = nvr -s -d $LOCAL $BASE $REMOTE $MERGED -c "wincmd J | wincmd ="
     ```
 
     `nvr -d` is a shortcut for `nvr -d -O` and acts like `vim -d`, thus it uses
@@ -257,7 +257,7 @@ Using nvr from within `:terminal`: ![Demo 2](https://github.com/mhinz/neovim-rem
     Unfortunately Neovim's API doesn't trigger any autocmds on its own, so simply
     `nvr /tmp` won't work. Meanwhile you can work around it like this:
 
-        $ nvr /tmp -c 'doautocmd BufEnter'
+        $ nvr /tmp -c "doautocmd BufEnter"
 
 - **Reading from stdin?**
 

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -184,8 +184,8 @@ def parse_args(argv):
 
         If no process is found, a new one will be started.
 
-            $ nvr --remote-send 'iabc<cr><esc>'
-            $ nvr --remote-expr 'map([1,2,3], \"v:val + 1\")'
+            $ nvr --remote-send "iabc<cr><esc>"
+            $ nvr --remote-expr "map([1,2,3], \'v:val + 1\')"
 
         Any arguments not consumed by options will be fed to --remote-silent:
 
@@ -196,8 +196,8 @@ def parse_args(argv):
         Exception: --remote-expr, --remote-send.
 
             $ nvr +10 file
-            $ nvr +'echomsg "foo" | echomsg "bar"' file
-            $ nvr --remote-tab-wait +'set bufhidden=delete' file
+            $ nvr +"echomsg 'foo' | echomsg 'bar'" file
+            $ nvr --remote-tab-wait +"set bufhidden=delete" file
 
         Open files in a new window from a terminal buffer:
 
@@ -205,7 +205,7 @@ def parse_args(argv):
 
         Use nvr from git to edit commit messages:
 
-            $ git config --global core.editor 'nvr --remote-wait-silent'
+            $ git config --global core.editor "nvr --remote-wait-silent"
     """)
 
     parser = argparse.ArgumentParser(
@@ -570,4 +570,3 @@ def main(argv=sys.argv, env=os.environ):
 
 if __name__ == '__main__':
     main()
-

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -38,6 +38,7 @@ class Nvr():
     def __init__(self, address, silent=False):
         self.address = address
         self.server = None
+        self.proc = None
         self.silent = silent
         self.wait = 0
         self.started_new_process = False
@@ -69,12 +70,12 @@ class Nvr():
         os.environ['NVIM_LISTEN_ADDRESS'] = self.address
 
         try:
-            pid = subprocess.Popen(args).pid
+            self.proc = subprocess.Popen(args)
         except FileNotFoundError:
             print("[!] Can't start new nvim process: '{}' is not in $PATH.".format(args[0]))
             sys.exit(1)
 
-        if pid:
+        if self.proc.pid:
             for i in range(10):
                 self.attach()
                 if self.server:
@@ -567,6 +568,8 @@ def main(argv=sys.argv, env=os.environ):
 
     nvr.server.close()
 
+    if nvr.started_new_process:
+        nvr.proc.wait()
 
 if __name__ == '__main__':
     main()

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -368,15 +368,16 @@ def print_addresses():
     errors = []
 
     for proc in psutil.process_iter(attrs=['name']):
-        if proc.info['name'] == 'nvim':
+        if proc.info['name'] in ['nvim', 'nvim.exe']:
             try:
                 for conn in proc.connections('inet4'):
                     addresses.insert(0, ':'.join(map(str, conn.laddr)))
                 for conn in proc.connections('inet6'):
                     addresses.insert(0, ':'.join(map(str, conn.laddr)))
-                for conn in proc.connections('unix'):
-                    if conn.laddr:
-                        addresses.insert(0, conn.laddr)
+                if os.name == 'posix':
+                    for conn in proc.connections('unix'):
+                        if conn.laddr:
+                            addresses.insert(0, conn.laddr)
             except psutil.AccessDenied:
                 errors.insert(0, 'Access denied for nvim ({})'.format(proc.pid))
 

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -38,7 +38,6 @@ class Nvr():
     def __init__(self, address, silent=False):
         self.address = address
         self.server = None
-        self.proc = None
         self.silent = silent
         self.wait = 0
         self.started_new_process = False
@@ -70,12 +69,12 @@ class Nvr():
         os.environ['NVIM_LISTEN_ADDRESS'] = self.address
 
         try:
-            self.proc = subprocess.Popen(args)
+            pid = subprocess.Popen(args).pid
         except FileNotFoundError:
             print("[!] Can't start new nvim process: '{}' is not in $PATH.".format(args[0]))
             sys.exit(1)
 
-        if self.proc.pid:
+        if pid:
             for i in range(10):
                 self.attach()
                 if self.server:
@@ -570,8 +569,6 @@ def main(argv=sys.argv, env=os.environ):
 
     nvr.server.close()
 
-    if nvr.started_new_process:
-        nvr.proc.wait()
 
 if __name__ == '__main__':
     main()

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -419,7 +419,9 @@ def main(argv=sys.argv, env=os.environ):
 
     if not nvr.server:
         silent = options.remote_silent or options.remote_wait_silent or options.remote_tab_silent or options.remote_tab_wait_silent or options.s
-        if not silent:
+        # Make noise only if user sets wrong servername or NVIM_LISTEN_ADDRESS
+        useraddr = options.servername or env.get('NVIM_LISTEN_ADDRESS')
+        if not silent and useraddr:
             show_message(address)
         if options.nostart:
             sys.exit(1)

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -25,7 +25,6 @@ THE SOFTWARE.
 import argparse
 import os
 import re
-import subprocess
 import sys
 import textwrap
 import time
@@ -66,15 +65,8 @@ class Nvr():
         args = os.environ.get('NVR_CMD')
         args = args.split(' ') if args else ['nvim']
 
-        os.environ['NVIM_LISTEN_ADDRESS'] = self.address
-
-        try:
-            pid = subprocess.Popen(args).pid
-        except FileNotFoundError:
-            print("[!] Can't start new nvim process: '{}' is not in $PATH.".format(args[0]))
-            sys.exit(1)
-
-        if pid:
+        pid = os.fork()
+        if pid == 0:
             for i in range(10):
                 self.attach()
                 if self.server:
@@ -84,6 +76,14 @@ class Nvr():
             print('[!] Unable to attach to the new nvim process. Is `{}` working?'
                     .format(" ".join(args)))
             sys.exit(1)
+        else:
+            os.environ['NVIM_LISTEN_ADDRESS'] = self.address
+            try:
+                os.dup2(sys.stdout.fileno(), sys.stdin.fileno())
+                os.execvpe(args[0], args, os.environ)
+            except FileNotFoundError:
+                print("[!] Can't start new nvim process: '{}' is not in $PATH.".format(args[0]))
+                sys.exit(1)
 
     def read_stdin_into_buffer(self, cmd):
         self.server.command(cmd)

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -407,7 +407,10 @@ def main(argv=sys.argv, env=os.environ):
         print_addresses()
         return
 
-    address = options.servername or env.get('NVIM_LISTEN_ADDRESS') or '/tmp/nvimsocket'
+    address = options.servername or env.get('NVIM_LISTEN_ADDRESS')
+    if not address:
+        # Since before build 17063 windows doesn't support unix socket, we need another way
+        address = '127.0.0.1:6789' if os.name == 'nt' else '/tmp/nvimsocket'
 
     nvr = Nvr(address, options.s)
     nvr.attach()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     python_requires  = '>=3.5',
     install_requires = ['pynvim', 'psutil', 'setuptools'],
     entry_points     = {
-        'console_scripts': ['nvr = nvr.nvr:main']
+        'console_scripts': ['nvr = nvr.nvr:main'],
+        'gui_scripts': ['gnvr = nvr.nvr:main']
     },
     packages         = ['nvr'],
     version          = '2.4.0',


### PR DESCRIPTION
So I finally get time trying to address issue #133. These patches include:

1. ~~Use subprocess.Popen instead of os.fork. As os.fork is dropped in Python 3.8, and doesn't work on Windows, I believe using subprocess.Popen is a better choice.~~ Use multiprocessing now, see #136 
2. Default tcp address: `127.0.0.1:6789` on Windows. Before build 17063 Windows doesn't support unix socket, so we use a tcp address. On *nix system, still use `/tmp/nvimsocket`.
3.  Fix `--serverlist` on Windows. `--serverlist` arg didn't work on Windows, this fixes it.
4. Also produce `gnvr` binary for GUI use. If you want to right-click something in file explorer and open it, just use `gnvr`. The difference from `nvr` is it doesn't bring up the ugly command line window if you are working on GUI desktop.
5. Use double quotes in doc. It seems on Windows args parsing is more strict/limited, outer single quotes usually are considered as errors. We use double quotes to avoid confusion.
6. Make noise only if user makes mistakes. i.e. `nvr` now should work out of the box. If no neovim instance is found, it will automatically help launch one(and do the rest work in queue, remote-expr, remote-send... etc). It also launches another instance if user explicitly designate an address with `--servername` to attach(but without success), unless `--nostart` is also given. This makes `nvr` flexible enough to run multiple neovim instances, and user friendly.

These patches also obsolete my `invr.au3` script.

Let me know if I break something :)