### PR TITLE
Fix `-d` not diffing the first file (closes #137)

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -488,7 +488,7 @@ def main2(nvr, options, arguments):
     if options.o:
         args = options.o + arguments
         if nvr.diffmode and not nvr.started_new_process:
-            nvr.fnameescaped_command('tabedit', args[0])
+            nvr.execute(args[:1], 'tabedit', silent=True, wait=False)
             nvr.execute(args[1:], 'split', silent=True, wait=False)
         else:
             nvr.execute(args, 'split', silent=True, wait=False)
@@ -496,7 +496,7 @@ def main2(nvr, options, arguments):
     elif options.O:
         args = options.O + arguments
         if nvr.diffmode and not nvr.started_new_process:
-            nvr.fnameescaped_command('tabedit', args[0])
+            nvr.execute(args[:1], 'tabedit', silent=True, wait=False)
             nvr.execute(args[1:], 'vsplit', silent=True, wait=False)
         else:
             nvr.execute(args, 'vsplit', silent=True, wait=False)


### PR DESCRIPTION
By using `Nvr.execute()` for the first file of a diff set as well, `Nvr.diffthis()` is called for every file involved.