### PR TITLE
Fix / Workaround: Trigger TermLeave autocommands when in Terminal mode

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -127,6 +127,11 @@ class Nvr():
     def execute(self, arguments, cmd='edit', silent=False, wait=False):
         cmds, files = split_cmds_from_files(arguments)
 
+        # if we are in terminal mode, leave it first, so TermLeave events are
+        # triggered
+        if (self.server.command_output('echo mode()') == 't'):
+            self.server.feedkeys(self.server.replace_termcodes('<c-\><c-n>', True, False, True), "n")
+
         for fname in files:
             if fname == '-':
                 self.read_stdin_into_buffer(stdin_cmd(cmd))
@@ -459,6 +464,7 @@ def main2(nvr, options, arguments):
         arguments = []
 
     if options.remote_send:
+        # might replace this with feedkeys to allow for remap / noremap cmds
         nvr.server.input(options.remote_send)
 
     if options.remote_expr:


### PR DESCRIPTION
hi there

i use ur plugin. however, my nvim config is such that when i leave Terminal Mode, i have numbers on the left and vise versa. this didn't work with opening a file with nvr inside a Terminal inside nvim.

i do not know whether this is a bug in neovim api itself that TermLeave event is not triggered, but i suspect so..

what this change does: detect whether were inside a terminal emulator. if so, leave terminal mode, then do as usual

best regards