### PR TITLE
Patches specifically for Windows platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ And do this in another shell:
 nvr --remote file1 file2
 
 # Send keys to the current buffer:
-nvr --remote-send 'iabc<esc>'
-# Enter insert mode, insert 'abc', and go back to normal mode again.
+nvr --remote-send "iabc<esc>"
+# Enter insert mode, insert "abc", and go back to normal mode again.
 
 # Evaluate any VimL expression, e.g. get the current buffer:
-nvr --remote-expr 'bufname("")'
+nvr --remote-expr "bufname("")"
 README.md
 ```
 
@@ -76,8 +76,8 @@ Remote control Neovim processes.
 
 If no process is found, a new one will be started.
 
-    $ nvr --remote-send 'iabc<cr><esc>'
-    $ nvr --remote-expr 'map([1,2,3], "v:val + 1")'
+    $ nvr --remote-send "iabc<cr><esc>"
+    $ nvr --remote-expr "map([1,2,3], 'v:val + 1')"
 
 Any arguments not consumed by options will be fed to --remote-silent:
 
@@ -88,8 +88,8 @@ All --remote options take optional commands.
 Exception: --remote-expr, --remote-send.
 
     $ nvr +10 file
-    $ nvr +'echomsg "foo" | echomsg "bar"' file
-    $ nvr --remote-tab-wait +'set bufhidden=delete' file
+    $ nvr +"echomsg 'foo' | echomsg 'bar'" file
+    $ nvr --remote-tab-wait +"set bufhidden=delete" file
 
 Open files in a new window from a terminal buffer:
 
@@ -97,7 +97,7 @@ Open files in a new window from a terminal buffer:
 
 Use nvr from git to edit commit messages:
 
-    $ git config --global core.editor 'nvr --remote-wait-silent'
+    $ git config --global core.editor "nvr --remote-wait-silent"
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -186,12 +186,12 @@ Happy hacking!
     Running `git commit` in a regular shell starts a nvim process. But in a
     terminal buffer (`:terminal`), a new nvim process starts as well. Now you
     have one nvim nested within another.
-    
+
     If you do not want this, put this in your vimrc:
 
     ```vim
-    if has('nvim')
-      let $GIT_EDITOR = 'nvr -cc split --remote-wait'
+    if has("nvim")
+      let $GIT_EDITOR = "nvr -cc split --remote-wait"
     endif
     ```
 
@@ -208,7 +208,7 @@ Happy hacking!
 
     To use nvr from a regular shell as well:
 
-        $ git config --global core.editor 'nvr --remote-wait-silent'
+        $ git config --global core.editor "nvr --remote-wait-silent"
 
 - **Use nvr as git mergetool.**
 
@@ -223,7 +223,7 @@ Happy hacking!
     [merge]
         tool = nvr
     [mergetool "nvr"]
-        cmd = nvr -s -d $LOCAL $BASE $REMOTE $MERGED -c 'wincmd J | wincmd ='
+        cmd = nvr -s -d $LOCAL $BASE $REMOTE $MERGED -c "wincmd J | wincmd ="
     ```
 
     `nvr -d` is a shortcut for `nvr -d -O` and acts like `vim -d`, thus it uses
@@ -257,7 +257,7 @@ Using nvr from within `:terminal`: ![Demo 2](https://github.com/mhinz/neovim-rem
     Unfortunately Neovim's API doesn't trigger any autocmds on its own, so simply
     `nvr /tmp` won't work. Meanwhile you can work around it like this:
 
-        $ nvr /tmp -c 'doautocmd BufEnter'
+        $ nvr /tmp -c "doautocmd BufEnter"
 
 - **Reading from stdin?**
 

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -184,8 +184,8 @@ def parse_args(argv):
 
         If no process is found, a new one will be started.
 
-            $ nvr --remote-send 'iabc<cr><esc>'
-            $ nvr --remote-expr 'map([1,2,3], \"v:val + 1\")'
+            $ nvr --remote-send "iabc<cr><esc>"
+            $ nvr --remote-expr "map([1,2,3], \'v:val + 1\')"
 
         Any arguments not consumed by options will be fed to --remote-silent:
 
@@ -196,8 +196,8 @@ def parse_args(argv):
         Exception: --remote-expr, --remote-send.
 
             $ nvr +10 file
-            $ nvr +'echomsg "foo" | echomsg "bar"' file
-            $ nvr --remote-tab-wait +'set bufhidden=delete' file
+            $ nvr +"echomsg 'foo' | echomsg 'bar'" file
+            $ nvr --remote-tab-wait +"set bufhidden=delete" file
 
         Open files in a new window from a terminal buffer:
 
@@ -205,7 +205,7 @@ def parse_args(argv):
 
         Use nvr from git to edit commit messages:
 
-            $ git config --global core.editor 'nvr --remote-wait-silent'
+            $ git config --global core.editor "nvr --remote-wait-silent"
     """)
 
     parser = argparse.ArgumentParser(

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -418,7 +418,9 @@ def main(argv=sys.argv, env=os.environ):
 
     if not nvr.server:
         silent = options.remote_silent or options.remote_wait_silent or options.remote_tab_silent or options.remote_tab_wait_silent or options.s
-        if not silent:
+        # Make noise only if user sets wrong servername or NVIM_LISTEN_ADDRESS
+        useraddr = options.servername or env.get('NVIM_LISTEN_ADDRESS')
+        if not silent and useraddr:
             show_message(address)
         if options.nostart:
             sys.exit(1)

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -368,15 +368,16 @@ def print_addresses():
     errors = []
 
     for proc in psutil.process_iter(attrs=['name']):
-        if proc.info['name'] == 'nvim':
+        if proc.info['name'] in ['nvim', 'nvim.exe']:
             try:
                 for conn in proc.connections('inet4'):
                     addresses.insert(0, ':'.join(map(str, conn.laddr)))
                 for conn in proc.connections('inet6'):
                     addresses.insert(0, ':'.join(map(str, conn.laddr)))
-                for conn in proc.connections('unix'):
-                    if conn.laddr:
-                        addresses.insert(0, conn.laddr)
+                if os.name == 'posix':
+                    for conn in proc.connections('unix'):
+                        if conn.laddr:
+                            addresses.insert(0, conn.laddr)
             except psutil.AccessDenied:
                 errors.insert(0, 'Access denied for nvim ({})'.format(proc.pid))
 

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -418,13 +418,18 @@ def main(argv=sys.argv, env=os.environ):
 
     if not nvr.server:
         silent = options.remote_silent or options.remote_wait_silent or options.remote_tab_silent or options.remote_tab_wait_silent or options.s
-        # Make noise only if user sets wrong servername or NVIM_LISTEN_ADDRESS
         useraddr = options.servername or env.get('NVIM_LISTEN_ADDRESS')
-        if not silent and useraddr:
-            show_message(address)
         if options.nostart:
+            # Make noise only if user sets wrong servername or NVIM_LISTEN_ADDRESS
+            if useraddr and not silent:
+                show_message(address)
             sys.exit(1)
         nvr.start_new_process(silent)
+        # Try again
+        if not nvr.server:
+            if useraddr and not silent:
+                show_message(address)
+            sys.exit(1)
 
     if not nvr.server:
         raise RuntimeError('This should never happen. Please raise an issue at https://github.com/mhinz/neovim-remote/issues')

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -407,7 +407,10 @@ def main(argv=sys.argv, env=os.environ):
         print_addresses()
         return
 
-    address = options.servername or env.get('NVIM_LISTEN_ADDRESS') or '/tmp/nvimsocket'
+    address = options.servername or env.get('NVIM_LISTEN_ADDRESS')
+    if not address:
+        # Since before build 17063 windows doesn't support unix socket, we need another way
+        address = '127.0.0.1:6789' if os.name == 'nt' else '/tmp/nvimsocket'
 
     nvr = Nvr(address, options.s)
     nvr.attach()

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -257,7 +257,7 @@ def parse_args(argv):
 
     parser.add_argument('--servername',
             metavar = '<addr>',
-            help    = 'Set the address to be used. This overrides the default "/tmp/nvimsocket" and $NVIM_LISTEN_ADDRESS.')
+            help    = 'Set the address to be used. This overrides the default serservername and $NVIM_LISTEN_ADDRESS.')
     parser.add_argument('--serverlist',
             action  = 'store_true',
             help    = 'Print the TCPv4 and Unix domain socket addresses of all nvim processes.')
@@ -307,7 +307,7 @@ def parse_args(argv):
     return parser.parse_known_args(argv[1:])
 
 
-def show_message(address):
+def show_message(useraddr, defaddr):
     print(textwrap.dedent('''
         [!] Can't connect to: {}
 
@@ -330,14 +330,13 @@ def show_message(address):
 
                 Expose $NVIM_LISTEN_ADDRESS to the environment before
                 using nvr or use its --servername option. If neither
-                is given, nvr assumes \"/tmp/nvimsocket\".
+                is given, nvr assumes {}.
 
                 $ NVIM_LISTEN_ADDRESS={} nvr file1 file2
                 $ nvr --servername {} file1 file2
-                $ nvr --servername 127.0.0.1:6789 file1 file2
 
             Use -s to suppress this message.
-        '''.format(address, address, address, address)))
+        '''.format(useraddr, defaddr, defaddr, defaddr, defaddr)))
 
 
 def split_cmds_from_files(args):
@@ -408,27 +407,27 @@ def main(argv=sys.argv, env=os.environ):
         print_addresses()
         return
 
-    address = options.servername or env.get('NVIM_LISTEN_ADDRESS')
-    if not address:
-        # Since before build 17063 windows doesn't support unix socket, we need another way
-        address = '127.0.0.1:6789' if os.name == 'nt' else '/tmp/nvimsocket'
+    useraddr = options.servername or env.get('NVIM_LISTEN_ADDRESS')
+    # Since before build 17063 windows doesn't support unix socket, we need another way
+    defaddr = '127.0.0.1:6789' if os.name == 'nt' else '/tmp/nvimsocket'
+
+    address = useraddr or defaddr
 
     nvr = Nvr(address, options.s)
     nvr.attach()
 
     if not nvr.server:
         silent = options.remote_silent or options.remote_wait_silent or options.remote_tab_silent or options.remote_tab_wait_silent or options.s
-        useraddr = options.servername or env.get('NVIM_LISTEN_ADDRESS')
         if options.nostart:
             # Make noise only if user sets wrong servername or NVIM_LISTEN_ADDRESS
             if useraddr and not silent:
-                show_message(address)
+                show_message(useraddr, defaddr)
             sys.exit(1)
         nvr.start_new_process(silent)
         # Try again
         if not nvr.server:
             if useraddr and not silent:
-                show_message(address)
+                show_message(useraddr, defaddr)
             sys.exit(1)
 
     if not nvr.server:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     python_requires  = '>=3.5',
     install_requires = ['pynvim', 'psutil', 'setuptools'],
     entry_points     = {
-        'console_scripts': ['nvr = nvr.nvr:main']
+        'console_scripts': ['nvr = nvr.nvr:main'],
+        'gui_scripts': ['gnvr = nvr.nvr:main']
     },
     packages         = ['nvr'],
     version          = '2.4.0',


### PR DESCRIPTION
These patches are based on lastest commit 1ec7c6c76a66d8d381f54570d6fdd3079c190ba5, an compilation of #135 and #136. The changes include:

1. Use multiprocessing module for Windows platform compatibility, i.e. neovim-remote now should work flawlessly on *nix systems and Windows.
2. Fixed `--serverlist` option. `--serverlist` arg didn't work on Windows, this fixed it.
3. Also produce `gnvr` binary for GUI use. If you want to add "Edit with Neovim" to right click menu, this is your thing. Your Windows registry entry should look like this:

        Windows Registry Editor Version 5.00

        [HKEY_CLASSES_ROOT\*\shell\nvim-qt]
        @="Edit with Neovim"
        "Icon"="\"C:\\tools\\neovim\\Neovim\\bin\\nvim-qt.exe\""

        [HKEY_CLASSES_ROOT\*\shell\nvim-qt\command]
        @="\"C:\\Program Files\\Python38-32\\Scripts\\gnvr.exe\" \"%1\""

        [HKEY_CLASSES_ROOT\Directory\shell\nvim-qt]
        @="Edit with Neovim"
        "Icon"="\"C:\\tools\\neovim\\Neovim\\bin\\nvim-qt.exe\""

        [HKEY_CLASSES_ROOT\Directory\shell\nvim-qt\command]
        @="\"C:\\Program Files\\Python38-32\\Scripts\\gnvr.exe\" \"%1\""

4. Nvr can lauch multiple neovim instances now. By default, nvr uses the address `127.0.0.1::6789` on Windows while `/tmp/nvimsocket` on *nix systems. But if you explicitly designate a valid `--servername` option, nvr will help start another neovim instance, unless `--nostart` option is included simultaneously.

5. Other minor fixes. Please refer to commit messages if you are interested.

@mhinz Please merge this PR instead, now it should have no conflict. If anyone want to try this, plesse clone this repo, checkout the `win_platform` branch, then type `python setup.py install` on your Windows prompt.

