### PR TITLE
Use tcp address on Windows

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -56,14 +56,14 @@ class Nvr():
             pass
 
     def try_attach(self, args, nvr, options, arguments):
-            for i in range(10):
-                self.attach()
-                if self.server:
-                    self.started_new_process = True
-                    return main2(nvr, options, arguments)
-                time.sleep(0.2)
-            print(f'[!] Unable to attach to the new nvim process. Is `{" ".join(args)}` working?')
-            sys.exit(1)
+        for i in range(10):
+            self.attach()
+            if self.server:
+                self.started_new_process = True
+                return proceed_after_attach(nvr, options, arguments)
+            time.sleep(0.2)
+        print(f'[!] Unable to attach to the new nvim process. Is `{" ".join(args)}` working?')
+        sys.exit(1)
 
     def execute_new_nvim_process(self, silent, nvr, options, arguments):
         if not silent:
@@ -436,10 +436,10 @@ def main(argv=sys.argv, env=os.environ):
             sys.exit(1)
         nvr.execute_new_nvim_process(silent, nvr, options, arguments)
 
-    main2(nvr, options, arguments)
+    proceed_after_attach(nvr, options, arguments)
 
 
-def main2(nvr, options, arguments):
+def proceed_after_attach(nvr, options, arguments):
     if options.d:
         nvr.diffmode = True
 

--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -414,7 +414,10 @@ def main(argv=sys.argv, env=os.environ):
         print_addresses()
         return
 
-    address = options.servername or env.get('NVIM') or env.get('NVIM_LISTEN_ADDRESS') or '/tmp/nvimsocket'
+    address = options.servername or env.get('NVIM') or env.get('NVIM_LISTEN_ADDRESS')
+    if not address:
+        # Since before build 17063 windows doesn't support unix socket, we need another way
+        address = '127.0.0.1:6789' if os.name == 'nt' else '/tmp/nvimsocket'
 
     nvr = Nvr(address, options.s)
     nvr.attach()


### PR DESCRIPTION
Since before build 17063 windows doesn't support unix socket, we need another way.

This PR also includes a minor renaming. I will create other PRs after we review and merge this.