### PR TITLE
fix(shortmess): remove hardcoded workaround

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -95,10 +95,7 @@ class Nvr():
         if not is_netrw_protocol(path):
             path = os.path.abspath(path)
         path = self.server.funcs.fnameescape(path)
-        shortmess = self.server.options['shortmess']
-        self.server.options['shortmess'] = shortmess.replace('F', '')
         self.server.command(f'{cmd} {path}')
-        self.server.options['shortmess'] = shortmess
 
     def diffthis(self):
         if self.diffmode:


### PR DESCRIPTION
**Why** is the change needed?

Based on my understanding of
https://github.com/mhinz/neovim-remote/issues/92#issuecomment-450494339,
this workaround is no longer needed. Being able to set `shortmess` is
useful for example when running in tmux.

Closes #153