### PR TITLE
Fix tests for neovim 0.8.0

### DIFF
--- a/tests/test_nvr.py
+++ b/tests/test_nvr.py
@@ -18,7 +18,7 @@ def run_nvr(cmdlines, env):
         nvr.main(cmdline, env)
 
 def setup_env():
-    env = {'NVIM_LISTEN_ADDRESS': 'pytest_socket_{}'.format(uuid.uuid4())}
+    env = {'NVIM_LISTEN_ADDRESS': './pytest_socket_{}'.format(uuid.uuid4())}
     env.update(os.environ)
     return env
 


### PR DESCRIPTION
Since neovim/neovim#8519, `NVIM_LISTEN_ADDRESS` is only directly used when it contains colons or (back-)slashes. Otherwise it is concatanated with a tempdir prefix and suffixes to form the final path.