### PR TITLE
Handle `str` in pynvim `NvimError`

### DIFF
--- a/nvr/nvr.py
+++ b/nvr/nvr.py
@@ -137,7 +137,12 @@ class Nvr():
                     else:
                         self.fnameescaped_command(cmd, fname)
                 except pynvim.api.nvim.NvimError as e:
-                    if not re.search('E37', e.args[0].decode()):
+                    err_str = (
+                        e.args[0]
+                        if isinstance(e.args[0], str)
+                        else e.args[0].decode()
+                    )
+                    if not re.search('E37', err_str):
                         traceback.print_exc()
                         sys.exit(1)
             self.diffthis()


### PR DESCRIPTION
I received the following error message running neovim-remote:

```
    Traceback (most recent call last):
      File "/nix/store/0ww738gzzxz5gnfla3bdmpfsp85y4s51-neovim-remote-2.5.1/lib/python3.10/site-packages/nvr/nvr.py", line 138, in execute
        self.fnameescaped_command(cmd, fname)
      File "/nix/store/0ww738gzzxz5gnfla3bdmpfsp85y4s51-neovim-remote-2.5.1/lib/python3.10/site-packages/nvr/nvr.py", line 100, in fnameescaped_command
        self.server.command(f'{cmd} {path}')
      File "/nix/store/flbgc27pg2zy7dy405pfg59lncd7lna0-python3.10-pynvim-0.4.3/lib/python3.10/site-packages/pynvim/api/nvim.py", line 287, in command
        return self.request('nvim_command', string, **kwargs)
      File "/nix/store/flbgc27pg2zy7dy405pfg59lncd7lna0-python3.10-pynvim-0.4.3/lib/python3.10/site-packages/pynvim/api/nvim.py", line 182, in request
        res = self._session.request(name, *args, **kwargs)
      File "/nix/store/flbgc27pg2zy7dy405pfg59lncd7lna0-python3.10-pynvim-0.4.3/lib/python3.10/site-packages/pynvim/msgpack_rpc/session.py", line 102, in request
        raise self.error_wrapper(err)
    pynvim.api.common.NvimError: BufReadPost Autocommands for "*": Vim(append):Error executing lua callback: ...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:21: Error executing lua: ...6-n>
    for language php
    stack traceback:
            [C]: in function '_ts_parse_query'
            ...ed-0.9.1/share/nvim/runtime/lua/vim/treesitter/query.lua:259: in function 'get'
            ...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:110: in function 'new'
            ...nwrapped-0.9.1/share/nvim/runtime/lua/vim/treesitter.lua:61: in function '_create_parser'
            ...nwrapped-0.9.1/share/nvim/runtime/lua/vim/treesitter.lua:131: in function 'get_parser'
            ...nwrapped-0.9.1/share/nvim/runtime/lua/vim/treesitter.lua:459: in function 'start'
            .../start/nvim-treesitter/lua/nvim-treesitter/highlight.lua:20: in function 'attach'
            ...es/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:509: in function 'attach_module'
            ...es/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:532: in function 'reattach_module'
            ...es/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:133: in function <...es/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:132>
            [C]: in function 'nvim_cmd'
            ...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:22: in function <...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:21>
            [C]: in function 'nvim_buf_call'
            ...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:21: in function <...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:10>
    stack traceback:
            [C]: in function 'nvim_cmd'
            ...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:22: in function <...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:21>
            [C]: in function 'nvim_buf_call'
            ...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:21: in function <...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:10>
    stack traceback:
            [C]: in function 'nvim_buf_call'
            ...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:21: in function <...6-neovim-unwrapped-0.9.1/share/nvim/runtime/filetype.lua:10>

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/nix/store/0ww738gzzxz5gnfla3bdmpfsp85y4s51-neovim-remote-2.5.1/bin/.nvr-wrapped", line 9, in <module>
        sys.exit(main())
      File "/nix/store/0ww738gzzxz5gnfla3bdmpfsp85y4s51-neovim-remote-2.5.1/lib/python3.10/site-packages/nvr/nvr.py", line 444, in main
        proceed_after_attach(nvr, options, arguments)
      File "/nix/store/0ww738gzzxz5gnfla3bdmpfsp85y4s51-neovim-remote-2.5.1/lib/python3.10/site-packages/nvr/nvr.py", line 463, in proceed_after_attach
        nvr.execute(options.remote_wait + arguments, 'edit', wait=True)
      File "/nix/store/0ww738gzzxz5gnfla3bdmpfsp85y4s51-neovim-remote-2.5.1/lib/python3.10/site-packages/nvr/nvr.py", line 140, in execute
        if not re.search('E37', e.args[0].decode()):
    AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```

Looks like this can be a str, so this change handles that case.